### PR TITLE
Only load RailsAdmin actions when it is defined.

### DIFF
--- a/lib/singleton-rails.rb
+++ b/lib/singleton-rails.rb
@@ -1,8 +1,9 @@
 require 'active_record' rescue nil
 
 if defined? ActiveRecord
-  require 'active_record/singleton'
-  require 'rails_admin/config/actions/singleton_aware_delete'
-  require 'rails_admin/config/actions/singleton_aware_index'
-  require 'rails_admin/config/actions/singleton_aware_new'
+  require "active_record/singleton"
+  if defined? RailsAdmin
+    require "rails_admin/config/actions/singleton_aware_delete"
+    require "rails_admin/config/actions/singleton_aware_index"
+  end	
 end


### PR DESCRIPTION
Fixes #6 

This fixes an error to be thrown when loading without using Rails Admin:

`singleton_aware_delete.rb:1:in`<top (required)>': uninitialized constant RailsAdmin (NameError)`
